### PR TITLE
Pillow 3.1 以降に対応

### DIFF
--- a/exif.py
+++ b/exif.py
@@ -55,10 +55,8 @@ with zipfile.ZipFile(path) as zipObj:
 			elif TAGS.get(key, key) == "ExifImageWidth":
 				width = val
 			elif TAGS.get(key, key) == "GPSInfo":
-				lat = (1 if val[1] == "N" else - 1) * (1.0 * val[2][0][0] /
-													   val[2][0][1] + 1.0 / 60 * val[2][1][0] / val[2][1][1])
-				lng = (1 if val[3] == "E" else - 1) * (1.0 * val[4][0][0] /
-													   val[4][0][1] + 1.0 / 60 * val[4][1][0] / val[4][1][1])
+				lat = (1 if val[1] == "N" else - 1) * (1.0 * val[2][0] + 1.0 / 60 * val[2][1])
+				lng = (1 if val[3] == "E" else - 1) * (1.0 * val[4][0] + 1.0 / 60 * val[4][1])
 		if DateTimeOriginal in programs:
 			programs[DateTimeOriginal].append({"DateTimeOriginal": DateTimeOriginal,
 											   "DateTime": DateTime,


### PR DESCRIPTION
実行時に `val[2][0][0]`  において `IFDRational object is not subscriptable` というエラーが発生します。
(Alpine Linux 3.13, Python 3.8.7, Pillow 8.2.0 で検証)

https://pillow.readthedocs.io/en/stable/releasenotes/3.1.0.html#tiffimageplugin-ifdrational によると、Pillow 3.1 以降で GPSInfo の情報を float ではなく IFDRational 型を使い格納するように変更されたようです。

したがって、IFDRational のままで処理が進むように変更しました。よろしくお願いします。