### PR TITLE
command name miss for multiplication

### DIFF
--- a/exif.py
+++ b/exif.py
@@ -118,7 +118,7 @@ while True:
 			data[addrto] += data[addrfrom]
 		elif target["command"] == "substraction":
 			data[addrto] -= data[addrfrom]
-		elif target["command"] == "multiplicatoin":
+		elif target["command"] == "multiplication":
 			data[addrto] *= data[addrfrom]
 		elif target["command"] == "division":
 			data[addrto] //= data[addrfrom]


### PR DESCRIPTION
There was a miss in a internal command name, and that made the multiplication feature not available.
